### PR TITLE
Fix for Issue 52: Hidden / Personal subquests are correctly displayed in quest details objectives.

### DIFF
--- a/module.json
+++ b/module.json
@@ -22,7 +22,7 @@
   "bugs": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-quest-log/issues",
   "changelog": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-quest-log/releases/latest/",
   "flags": {},
-  "version": "0.7.2",
+  "version": "0.7.3",
   "minimumCoreVersion": "0.8.7",
   "compatibleCoreVersion": "0.8.8",
   "esmodules": [

--- a/modules/control/Enrich.js
+++ b/modules/control/Enrich.js
@@ -158,13 +158,13 @@ export default class Enrich
       {
          for (const questId of data.subquests)
          {
-            const subData = Fetch.quest(questId);
+            const subquest = Fetch.quest(questId);
 
-            if (subData)
+            if (subquest && subquest.isObservable)
             {
                // Mirror Task data for state / button state
                let state = 'square';
-               switch (subData.status)
+               switch (subquest.status)
                {
                   case 'completed':
                      state = 'check-square';
@@ -174,13 +174,17 @@ export default class Enrich
                      break;
                }
 
+               const subPersonalActors = subquest.getPersonalActors();
+
                data.data_subquest.push({
                   id: questId,
-                  giver: subData.giver,
-                  name: subData.name,
-                  status: subData.status,
+                  giver: subquest.giver,
+                  name: subquest.name,
+                  status: subquest.status,
                   state,
-                  isObservable: subData.isObservable
+                  isHidden: subquest.isHidden,
+                  isPersonal: subPersonalActors.length > 0,
+                  personalActors: subPersonalActors.map((a) => a.name).sort((a, b) => a.localeCompare(b)).join('&#013;')
                });
             }
          }

--- a/modules/view/QuestPreview.js
+++ b/modules/view/QuestPreview.js
@@ -726,8 +726,10 @@ export default class QuestPreview extends FormApplication
                      if (app.appId === this._permControl.appId)
                      {
                         this._permControl = void 0;
+                        const questId = this.quest.parent ? [this.quest.parent, this.quest.id] : this.quest.id;
+
                         Socket.refreshQuestLog();
-                        Socket.refreshQuestPreview({ questId: this.quest.id });
+                        Socket.refreshQuestPreview({ questId });
                      }
                   });
                }

--- a/templates/partials/quest-preview/details.html
+++ b/templates/partials/quest-preview/details.html
@@ -107,6 +107,10 @@
                     <i class="fas fa-times state {{#unless (eq status 'failed')}}hidden{{/unless}}"></i>
                   </span>
                 </div>
+                {{#if ../isGM}}
+                   {{#if isHidden}}<i class="is-hidden fas fa-eye-slash" title="{{localize 'ForienQuestLog.Tooltips.HiddenQuestNoPlayers'}}"></i>{{/if}}
+                   {{#if isPersonal}}<i class="is-personal fas fa-user-shield" title="{{{personalActors}}}"></i>{{/if}}
+                {{/if}}
                 <p class="quest-name" data-id="{{id}}">{{name}} <i class="fas fa-link"></i></p>
                 {{#if ../isGM}}
                 <div class="actions">


### PR DESCRIPTION
This fixes Issue #52. Subquests in the objectives list were shown to all players regardless of permission settings. IE Hidden & personal quests were shown to all players. This PR produces the correct visibility for the players and shows the GM the hidden / personal icon for the subquest in the objectives list of a parent quest.

I have bumped the module.json version to `0.7.3`. This is indeed worth releasing now. Alas. It's not a crash type event, but a significant fix.

Seriously just needed more help with monkey testing... :O 

GM View left (mouse pointer is hidden in screenshot but hovering over personal quest icon)
Player view on the right w/ correct permissions for subquests:
![fql-hidden-subquests](https://user-images.githubusercontent.com/311473/123458348-ccf12380-d599-11eb-9fd7-c70ec4003e5d.png)

