### PR TITLE
Added ability for user-selected default Abstract Rewards icon

### DIFF
--- a/modules/view/QuestPreview.js
+++ b/modules/view/QuestPreview.js
@@ -674,7 +674,7 @@ export default class QuestPreview extends FormApplication
                   this.quest.addReward({
                      data: {
                         name: value,
-                        img: 'icons/svg/mystery-man.svg'
+                        img: 'FQL/defultAbstract.jpg'
                      },
                      hidden: true,
                      type: 'Abstract'


### PR DESCRIPTION
- Changed the path in QuestPreview.js (line 677) to point to a user-created folder/image. 
- Requires user to create a folder in the user data folder named FQL. (_\AppData\Local\FoundryVTT\Data\FQL_) 
- A jpg image may be placed in this folder and when renamed to _defaultAbstract.jpg_ it will be the default icon for newly created Abstract Rewards. 

<img src ="https://user-images.githubusercontent.com/79543184/123717964-fd5fe880-d84b-11eb-851b-0694591d074d.gif" width = "65%"/>

**note:** I considered png or svg files instead of jpg but I think that the average user will have more access to jpg icon images, especially considering how many are included in Foundry/D&D 5E/Etc.