### PR TITLE
Add CONTRIBUTING.md to repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@ Open Source projects function most efficiently when everyone plays nicely with e
 
 * If applicable, **use the appropriate issue templates** to automatically apply the relevant tag to the created issue. This allows issues to be quickly differentiated as bug reports, enchancement suggestions, or whatever else without a maintainer manually adding the tag to the issue. The bug report template will specify which information to add that will aid in reproducing the bug.
 
+* Inconsequential fixes regarding typos, whitespace, etc may not warrant an issue and can skip straight to the Pull Request.
+
 ### **Do you want to fix a currently existing issue?**
 
 * Before working on an issue, please **honor issue assignments** and ask to be assigned to the issue on that issue's page. This allows everyone else to see that someone is working on the issue, preventing any duplicate pull requests down the line. If someone is already assigned to the issue, feel free to reach out to the assignee and inquire on the progress of that fix.
@@ -15,7 +17,7 @@ Open Source projects function most efficiently when everyone plays nicely with e
 
 * When you feel your fork adequately fixes an issue, **submit a pull request for review**! [Please indicate which issue is to be closed if the PR is merged](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) as well as giving a detailed overview of your changes. 
 
-* Please **limit the content of your pull requests to the implementation of the issue fix**. If your pull request does anything additional, you must first open an issue that your PR may close (see the below section).
+* Please **limit the content of your pull requests to its linked issues**. If your pull request does anything additional, you must first open an issue that your PR may close (see the below section).
 
 ### **Do you intend to add a new feature or change an existing one?**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+## Contribution Etiquette
+Open Source projects function most efficiently when everyone plays nicely with each other. Here are some suggested practices that will let everyone else work alongside you comfortably:
+
+### **Did you find a bug? Do you want to suggest an enhancement?**
+
+* **Ensure your contribution is novel** by searching the [Issues](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-quest-log/issues) page. Be sure to look through both open and closed issues, especially for enhancement suggestions as rejected suggestions will be closed.
+
+* If applicable, **use the appropriate issue templates** to automatically apply the relevant tag to the created issue. This allows issues to be quickly differentiated as bug reports, enchancement suggestions, or whatever else without a maintainer manually adding the tag to the issue. The bug report template will specify which information to add that will aid in reproducing the bug.
+
+### **Do you want to fix a currently existing issue?**
+
+* Before working on an issue, please **honor issue assignments** and ask to be assigned to the issue on that issue's page. This allows everyone else to see that someone is working on the issue, preventing any duplicate pull requests down the line. If someone is already assigned to the issue, feel free to reach out to the assignee and inquire on the progress of that fix.
+
+* While working on an issue, **document your changes** by providing detailed commit messages and providing an overview of planned/current implementation/changes/etc on the issue's page. 
+
+* When you feel your fork adequately fixes an issue, **submit a pull request for review**! [Please indicate which issue is to be closed if the PR is merged](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) as well as giving a detailed overview of your changes. 
+
+* Please **limit the content of your pull requests to the implementation of the issue fix**. If your pull request does anything additional, you must first open an issue that your PR may close (see the below section).
+
+### **Do you intend to add a new feature or change an existing one?**
+
+* Please **open an issue** to generate feedback on the change first. The maintainers reserve the right to reject changes/additions that they do not want to maintain, so be sure that the maintainers are on the same page as you to avoid wasted work!
+
+* Now that an issue covers the changes you wanted to make, refer to the above section for implementing the changes.
+
+### **Do you want to submit/update a translation?**
+
+* **Submit a pull request** with your new/updated JSON file in the [lang folder](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-quest-log/tree/master/lang).
+
+* Be sure that the JSON file is either completely flat or completely nested, rather than some combination of both.
+
+* If your localization does not include translations for any strings, please indicate as much in the [lang/missing folder](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-quest-log/tree/master/lang/missing).
+
+### **Do you want to contribute documentation?**
+
+* For now, **wait until [Issue #55](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-quest-log/issues/55) is closed**. When this repo has a wiki page, documentation will go there.
+
+* Please **follow the above guidelines** regarding opening issues and submitting pull requests. Some documentation issues may be more broad and be ongoing, in which case you may want to contribute to assignee's forks first. Any smaller changes should still open a detailed issue and submit a detailed pull request that [closes that issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+### **Do you have questions about the source code?**
+
+* **Join the [League Discord](https://discord.gg/gzemMfHURH)** and direct questions to the appropriate channels, optionally pinging maintainers.
+
+* Please **do not directly contact maintainers** with questions; if you have a question other people might as well, so discussions should take place in public forums where others can see and learn from it as well.
+
+Thank you for your interest in contributing to Forien's Quest Log! :heart:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Open Source projects function most efficiently when everyone plays nicely with e
 
 * **Ensure your contribution is novel** by searching the [Issues](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-quest-log/issues) page. Be sure to look through both open and closed issues, especially for enhancement suggestions as rejected suggestions will be closed.
 
-* If applicable, **use the appropriate issue templates** to automatically apply the relevant tag to the created issue. This allows issues to be quickly differentiated as bug reports, enchancement suggestions, or whatever else without a maintainer manually adding the tag to the issue. The bug report template will specify which information to add that will aid in reproducing the bug.
+* If applicable, **use the appropriate issue templates** to automatically apply the relevant tag to the created issue. This allows issues to be quickly differentiated as bug reports, enhancement suggestions, or whatever else without a maintainer manually adding the tag to the issue. The bug report template will specify which information to add that will aid in reproducing the bug.
 
 * Inconsequential fixes regarding typos, whitespace, etc may not warrant an issue and can skip straight to the Pull Request.
 
@@ -37,7 +37,7 @@ Open Source projects function most efficiently when everyone plays nicely with e
 
 * For now, **wait until [Issue #55](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-quest-log/issues/55) is closed**. When this repo has a wiki page, documentation will go there.
 
-* Please **follow the above guidelines** regarding opening issues and submitting pull requests. Some documentation issues may be more broad and be ongoing, in which case you may want to contribute to assignee's forks first. Any smaller changes should still open a detailed issue and submit a detailed pull request that [closes that issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+* Please **follow the above guidelines** regarding opening issues and submitting pull requests. Some documentation issues may be broader and ongoing, in which case you may want to contribute to assignee's forks first. Any smaller changes should still open a detailed issue and submit a detailed pull request that [closes that issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
 
 ### **Do you have questions about the source code?**
 


### PR DESCRIPTION
Fixes #76

Adds a document that gives guidelines on how outside contributors should approach this repo to contribute to it. Please note that the current contents of the file contain guidelines that I find appropriate, but the final contents of the file should reflect the guidelines that the maintainers of this repo would like contributors to adhere to.