### PR TITLE
`0.7.5` release - fix for #98 and small quality of life changes.

### DIFF
--- a/module.json
+++ b/module.json
@@ -24,7 +24,7 @@
   "flags": {
     "allowBugReporter": true
   },
-  "version": "0.7.4",
+  "version": "0.7.5",
   "minimumCoreVersion": "0.8.6",
   "compatibleCoreVersion": "0.8.8",
   "scripts": [],

--- a/src/ModuleSettings.js
+++ b/src/ModuleSettings.js
@@ -103,7 +103,7 @@ export default class ModuleSettings
          hint: 'ForienQuestLog.Settings.countHidden.EnableHint',
          scope: scope.world,
          config: true,
-         default: true,
+         default: false,
          type: Boolean,
          onChange: () =>
          {

--- a/src/control/Utils.js
+++ b/src/control/Utils.js
@@ -237,9 +237,11 @@ export default class Utils
     * Presently (06/10/21) there isn't a way to hide the embed tag. It should be noted though that the media field
     * of TinyMCE does have a XSS sanitation filter disabling scripts in embedded content.
     *
+    * @param {string}   [initialContent=''] - The initial content of the editor. Used to reset content via `Esc` key.
+    *
     * @returns {object} TinyMCE options
     */
-   static tinyMCEOptions()
+   static tinyMCEOptions(initialContent = '')
    {
       return {
          plugins: "emoticons hr image link lists media charmap table save",
@@ -267,7 +269,7 @@ export default class Utils
             {
                if (e.keyCode === 27)
                {
-                  editor.resetContent();
+                  editor.resetContent(initialContent);
                   setTimeout(() => editor.execCallback('save_onsavecallback'), 0);
                }
             }));

--- a/src/model/constants.js
+++ b/src/model/constants.js
@@ -15,7 +15,7 @@ const constants = {
 /**
  * Defines the {@link JQuery} events that are used in FQL.
  *
- * @type {{drop: string, focusout: string, dragstart: string, focus: string, click: string, mousedown: string}}
+ * @type {{click: string, dragstart: string, drop: string, focus: string, focusout: string, mousedown: string}}
  */
 const jquery = {
    click: 'click',
@@ -23,6 +23,7 @@ const jquery = {
    drop: 'drop',
    focus: 'focus',
    focusout: 'focusout',
+   keydown: 'keydown',
    mousedown: 'mousedown'
 };
 

--- a/src/view/preview/HandlerDetails.js
+++ b/src/view/preview/HandlerDetails.js
@@ -34,6 +34,9 @@ export default class HandlerDetails
       parent.append(input);
       input.trigger(jquery.focus);
 
+      // If the HTMLElement has setSelectionRange then set cursor to the end.
+      if (input[0]?.setSelectionRange) { input[0].setSelectionRange(value.length, value.length); }
+
       /**
        * Store the input focus callback in the associated QuestPreview instance so that it can be invoked if the app is
        * closed in {@link QuestPreview.close} while the input field is focused / being edited allowing any edits to be
@@ -65,6 +68,16 @@ export default class HandlerDetails
       };
 
       input.on(jquery.focusout, questPreview._activeFocusOutFunction);
+      input.on(jquery.keydown, (event) =>
+      {
+         // Handle `Esc` key down to cancel editing.
+         if (event.which === 27)
+         {
+            questPreview._activeFocusOutFunction = void 0;
+            questPreview.render(true, { focus: true });
+            return false;
+         }
+      });
    }
 
    /**
@@ -91,6 +104,9 @@ export default class HandlerDetails
       parent.html('');
       parent.append(input);
       input.trigger(jquery.focus);
+
+      // If the HTMLElement has setSelectionRange then set cursor to the end.
+      if (input[0]?.setSelectionRange) { input[0].setSelectionRange(value.length, value.length); }
 
       /**
        * Store the input focus callback in the associated QuestPreview instance so that it can be invoked if the app is
@@ -124,6 +140,16 @@ export default class HandlerDetails
       };
 
       input.on(jquery.focusout, questPreview._activeFocusOutFunction);
+      input.on(jquery.keydown, (event) =>
+      {
+         // Handle `Esc` key down to cancel editing.
+         if (event.which === 27)
+         {
+            questPreview._activeFocusOutFunction = void 0;
+            questPreview.render(true, { focus: true });
+            return false;
+         }
+      });
    }
 
    /**
@@ -284,6 +310,9 @@ export default class HandlerDetails
       parent.append(input);
       input.trigger(jquery.focus);
 
+      // If the HTMLElement has setSelectionRange then set cursor to the end.
+      if (input[0]?.setSelectionRange) { input[0].setSelectionRange(value.length, value.length); }
+
       /**
        * Store the input focus callback in the associated QuestPreview instance so that it can be invoked if the app is
        * closed in {@link QuestPreview.close} while the input field is focused / being edited allowing any edits to be
@@ -320,6 +349,16 @@ export default class HandlerDetails
       };
 
       input.on(jquery.focusout, questPreview._activeFocusOutFunction);
+      input.on(jquery.keydown, (event) =>
+      {
+         // Handle `Esc` key down to cancel editing.
+         if (event.which === 27)
+         {
+            questPreview._activeFocusOutFunction = void 0;
+            questPreview.render(true, { focus: true });
+            return false;
+         }
+      });
    }
 
    /**
@@ -361,6 +400,15 @@ export default class HandlerDetails
             });
          }
          await questPreview.saveQuest();
+      });
+      input.on(jquery.keydown, (event) =>
+      {
+         // Handle `Esc` key down to cancel editing.
+         if (event.which === 27)
+         {
+            questPreview.render(true, { focus: true });
+            return false;
+         }
       });
    }
 
@@ -723,6 +771,15 @@ export default class HandlerDetails
          }
          await questPreview.saveQuest();
       });
+      input.on(jquery.keydown, (event) =>
+      {
+         // Handle `Esc` key down to cancel editing.
+         if (event.which === 27)
+         {
+            questPreview.render(true, { focus: true });
+            return false;
+         }
+      });
    }
 
    /**
@@ -819,6 +876,9 @@ export default class HandlerDetails
       parent.append(input);
       input.trigger(jquery.focus);
 
+      // If the HTMLElement has setSelectionRange then set cursor to the end.
+      if (input[0]?.setSelectionRange) { input[0].setSelectionRange(value.length, value.length); }
+
       /**
        * Store the input focus callback in the associated QuestPreview instance so that it can be invoked if the app is
        * closed in {@link QuestPreview.close} while the input field is focused / being edited allowing any edits to be
@@ -855,6 +915,16 @@ export default class HandlerDetails
       };
 
       input.on(jquery.focusout, questPreview._activeFocusOutFunction);
+      input.on(jquery.keydown, (event) =>
+      {
+         // Handle `Esc` key down to cancel editing.
+         if (event.which === 27)
+         {
+            questPreview._activeFocusOutFunction = void 0;
+            questPreview.render(true, { focus: true });
+            return false;
+         }
+      });
    }
 
    /**

--- a/src/view/preview/QuestPreview.js
+++ b/src/view/preview/QuestPreview.js
@@ -367,7 +367,7 @@ export default class QuestPreview extends FormApplication
     */
    activateEditor(name, options = {}, initialContent = '')
    {
-      super.activateEditor(name, Object.assign({}, options, Utils.tinyMCEOptions()), initialContent);
+      super.activateEditor(name, Object.assign({}, options, Utils.tinyMCEOptions(initialContent)), initialContent);
    }
 
    /**


### PR DESCRIPTION
Fix for issue #98: `Esc` now properly resets initial content instead of enhanced initial content.

Small quality of life improvements for single input line editing. `Esc` key will cancel editing of single input line edits for:
- quest name
- custom quest giver name
- objective content
- abstract reward content
- add abstract reward
- add objective

Also when editing an existing input field the cursor is set to the end of the input instead of the beginning.