### PR TITLE
Correct handlebar helper name to prevent conflicts

### DIFF
--- a/src/control/Utils.js
+++ b/src/control/Utils.js
@@ -383,7 +383,7 @@ export default class Utils
     */
    static registerHandlebarsHelpers()
    {
-      Handlebars.registerHelper('format', (stringId, ...arrData) =>
+      Handlebars.registerHelper('fql_format', (stringId, ...arrData) =>
       {
          let objData;
          if (typeof arrData[0] === 'object')

--- a/templates/partials/quest-log/tab.html
+++ b/templates/partials/quest-log/tab.html
@@ -1,5 +1,5 @@
 <header>
-  <h1 style="flex: 1;">{{format 'ForienQuestLog.Quests' (localize (lookup questStatusI18n tab))}}</h1>
+  <h1 style="flex: 1;">{{fql_format 'ForienQuestLog.Quests' (localize (lookup questStatusI18n tab))}}</h1>
   {{#if (or isGM canCreate)}}
     <button class="new-quest-btn"><i class="fas fa-plus"></i> {{localize 'ForienQuestLog.Buttons.AddNewQuest'}}</button>
   {{/if}}
@@ -23,7 +23,7 @@
       <div class="title" data-quest-id="{{id}}">
         <h2>{{name}}</h2>
         {{#if isSubquest}}
-          <p class="subquest">{{format 'ForienQuestLog.QuestPreview.SubTitle' data_parent.name}}</p>
+          <p class="subquest">{{fql_format 'ForienQuestLog.QuestPreview.SubTitle' data_parent.name}}</p>
         {{/if}}
       </div>
       {{#unless (eq ../../showTasks 'no')}}

--- a/templates/partials/quest-preview/details.html
+++ b/templates/partials/quest-preview/details.html
@@ -57,7 +57,7 @@
           </p>
           {{#if isSubquest}}
             <p class="quest-name-link" data-quest-id="{{data_parent.id}}">
-              {{format 'ForienQuestLog.QuestPreview.SubTitle' data_parent.name}}
+              {{fql_format 'ForienQuestLog.QuestPreview.SubTitle' data_parent.name}}
               <i class="fas fa-link"></i>
               {{#if data_parent.isPrimary}}<i class="is-primary fas fa-star" title="{{localize 'ForienQuestLog.Tooltips.PrimaryQuest'}}"></i>{{/if}}
             </p>


### PR DESCRIPTION
Renamed the custom Handlebars Helper from `format` to `fql_format` to prevent potential conflicts with other modules.