### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/lang/fi-FI.json
+++ b/lang/fi-FI.json
@@ -6,7 +6,7 @@
           "OpenMacro": "Avaa ”{name}”"
         },
         "Notifications": {
-          "NoQuest": "API virhe: Makroa ei voida luoda kelvottomalla tehtävän ID:llä."
+          "NoQuest": "API virhe: Makroa ei voi luoda kelvottomalla tehtävän tunnisteella."
         }
       },
       "QuestDB": {
@@ -16,12 +16,12 @@
       },
       "Socket": {
         "Notifications": {
-          "RewardDrop": "FQL (palkkio): {userName} raahasi tavaran '{itemName}' hahmolle {actorName}."
+          "RewardDrop": "FQL (palkkio): {userName} raahasi tavaran \"{itemName}\" hahmolle {actorName}."
         }
       },
       "Utils": {
         "Notifications": {
-          "NoDocument": "Entiteettiä ei voitu ladata UUID:llä: '{uuid}'.",
+          "NoDocument": "Entiteettiä ei voitu ladata UUID:llä \"{uuid}\".",
           "NoPermission": "Sinulla ei ole tarvittavia oikeuksia nähdä tämän entiteetin lomaketta."
         }
       }
@@ -32,7 +32,7 @@
       "BodyReward": "Tämä palkkio ja sen tiedot poistetaan lopullisesti.",
       "Cancel": "Peruuta",
       "Delete": "Poista",
-      "HeaderDel": "Haluatko varmasti poistaa: <p>'{name}'</p>",
+      "HeaderDel": "Haluatko varmasti poistaa: <p>\"{name}\"</p>",
       "TitleDel": "Poista {title}"
     },
     "Labels": {
@@ -51,8 +51,8 @@
       },
       "Notifications": {
         "Complete": "Forien's Quest Log - Tietojen siirto valmis.",
-        "CouldNotMigrate": "Forien's Quest Log - Tehtävää ei voitu siirtää: '{name}'.",
-        "Schema": "Forien's Quest Log - Tietoja siirretään skeeman versioon '{version}'.",
+        "CouldNotMigrate": "Forien's Quest Log - Tehtävää ei voitu siirtää: \"{name}\".",
+        "Schema": "Forien's Quest Log - Tietoja siirretään skeeman versioon \"{version}\".",
         "Start": "Forien's Quest Log - Tietoja siirretään, ethän lataa sivua uudelleen."
       }
     },
@@ -60,12 +60,12 @@
       "CannotOpen": "Tehtävän yksityiskohtia ei voi avata. Tämä tehtävä ei välttämättä ole havaittavissa tai sitä ei enää ole.",
       "FinishQuestAdded": "Teethän muokkauksesi loppuun ja suljet nykyisen tehtävän, ennen kuin lisäät uuden.",
       "LinkCopied": "Entiteetin linkki tähän tehtävään kopioitiin leikepöydälle.",
-      "QuestAdded": "Uusi tehtävä '{name}' lisättiin tilalla: '{status}'.",
-      "QuestIDCopied": "Tämän tehtävän ID kopioitiin leikepöydälle.",
-      "QuestMoved": "'{name}' siirrettiin uudeksi tilaksi asetettiin: '{target}'.",
-      "QuestPrimary": "'{name}' on uusi päätehtävä.",
+      "QuestAdded": "Uusi tehtävä \"{name}\" lisättiin tilassa \"{status}\".",
+      "QuestIDCopied": "Tämän tehtävän tunniste kopioitiin leikepöydälle.",
+      "QuestMoved": "\"{name}\" siirrettiin ja uudeksi tilaksi asetettiin \"{target}\".",
+      "QuestPrimary": "\"{name}\" on uusi päätehtävä.",
       "QuestTrackerNoActive": "Tehtäväseurain on päällä, mutta keskeneräisiä tehtäviä ei tällä hetkellä ole.",
-      "UserCantOpen": "Käyttäjällä '{user}' ei ole oikeuksia avata tätä tehtävää."
+      "UserCantOpen": "Käyttäjällä \"{user}\" ei ole oikeuksia avata tätä tehtävää."
     },
     "QuestLog": {
       "Buttons": {
@@ -73,7 +73,7 @@
       },
       "ContextMenu": {
         "CopyEntityLink": "Kopioi entiteetin sisältölinkki",
-        "CopyQuestID": "Kopioi tehtävän ID",
+        "CopyQuestID": "Kopioi tehtävän tunniste",
         "PrimaryQuest": "Aseta / poista päätehtäväksi"
       },
       "Labels": {
@@ -88,7 +88,7 @@
     "QuestPreview": {
       "Buttons": {
         "RewardCustom": "Käyttäjän Määrittelemä",
-        "RewardHide": "Kätkeä",
+        "RewardHide": "Piilota",
         "RewardLock": "Lukita",
         "RewardShow": "Näyttää",
         "RewardUnlock": "Avata"
@@ -115,7 +115,7 @@
         "SplashQuestIcon": "Aseta tehtävän kuvakkeeksi"
       },
       "Notifications": {
-        "BadUUID": "Dokumenttia ei löytynyt UUID:llä: '{uuid}'.",
+        "BadUUID": "Dokumenttia ei löytynyt UUID:llä \"{uuid}\".",
         "WrongDocType": "Forien's Quest Log hyväksyy vain maailman / hakemiston hahmoja, tavaroita ja muistiinpanoja tehtävänantajiksi.",
         "WrongItemType": "Forien's Quest Log hyväksyy vain maailman ja hakemiston tavaroita palkkioiksi."
       },
@@ -140,10 +140,10 @@
         "RewardLockedPlayer": "Palkkio on lukittu.",
         "RewardUnlocked": "Palkkio on lukitsematon. Napsauta lukitaksesi sen.",
         "RewardUnlockedPlayer": "Palkkiota ei ole lukittu.",
-        "RewardVisible": "Palkkio on näkyvillä. Paina piilottaaksesi sen.",
+        "RewardVisible": "Palkkio on näkyvillä. Napsauta piilottaaksesi sen.",
         "ShowAll": "Näytä kaikki",
-        "TaskHidden": "Tavoite on piilotettu. Paina näyttääksesi sen.",
-        "TaskVisible": "Tavoite on näkyvillä. Paina piilottaaksesi sen.",
+        "TaskHidden": "Tavoite on piilotettu. Napsauta näyttääksesi sen.",
+        "TaskVisible": "Tavoite on näkyvillä. Napsauta piilottaaksesi sen.",
         "ToggleImage": "Näytä / piilota pelinappulan / hahmon kuva.",
         "UnlockAll": "Avaa lukitus kaikista",
         "ViewSplashArt": "Katso kansikuva."
@@ -189,7 +189,7 @@
       },
       "allowPlayersCreate": {
         "Enable": "Pelaajat voivat luoda tehtäviä",
-        "EnableHint": "Valitse salliaksesi pelaajien luoda tehtäviä. Pelaajien luomat tehtävät ilmestyvät Saatavilla-välilehdelle Pelaajan muokattava -oikeuksilla. VAATII 'luoda muistiinpanoja' ydinoikeuden."
+        "EnableHint": "Valitse salliaksesi pelaajien luoda tehtäviä. Pelaajien luomat tehtävät ilmestyvät Saatavilla-välilehdelle Pelaajan muokattava -oikeuksilla. VAATII Luoda muistiinpanoja -ydinoikeuden."
       },
       "allowPlayersDrag": {
         "Enable": "Salli pelaajien raahata palkkioita",
@@ -236,7 +236,7 @@
         "default": "Näytä tavoitteet: suoritettu / kaikki",
         "Enable": "Näytä tavoitteet tehtävälokissa",
         "EnableHint": "Valitse kuinka tavoitteiden määrä näytetään tehtävän otsikon vieressä tehtävälokissa. Tämä ei vaikuta tehtävän esikatseluun.",
-        "no": "Piilota 'Tavoitteet' sarake",
+        "no": "Piilota Tavoitteet-sarake",
         "onlyCurrent": "Näytä tavoitteet: suoritettu"
       },
       "trustedPlayerEdit": {


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [Forien's Quest Log/main](https://weblate.foundryvtt-hub.com/projects/forien-quest-log/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/forien-quest-log/-/main/horizontal-auto.svg)