### PR TITLE
Added support for monks-enjanced-journals so that when a quest refere…

### DIFF
--- a/src/control/Enrich.js
+++ b/src/control/Enrich.js
@@ -89,10 +89,11 @@ export default class Enrich
                   break;
 
                case JournalEntry.documentName:
+                  const imageSrc = document?.flags['monks-enhanced-journal']?.img ?? FVTTCompat.journalImage(document);
                   data = {
                      uuid,
                      name: document.name,
-                     img: FVTTCompat.journalImage(document),
+                     img: imageSrc,
                      hasTokenImg: false
                   };
                   break;


### PR DESCRIPTION
Added support for monks enhanced journals which currently returns undefined since it sets the image at an alternative flag location. This was done by checking the path for the monks-enhanced-journal image and if it is undefined it will look in the traditional location.

close #42 