### PR TITLE
Update for  Foundry v12

### DIFF
--- a/database/dbSchema_1.js
+++ b/database/dbSchema_1.js
@@ -45,7 +45,7 @@ export default async function()
             const quest = new Quest(content, entry);
 
             // Accept the default permission if defined otherwise set to observer.
-            const defaultPermission = FVTTCompat.ownership(entry)?.default ?? CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER;
+            const defaultPermission = FVTTCompat.ownership(entry)?.default ?? CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER;
 
             const data = {
                name: quest.name,

--- a/module.json
+++ b/module.json
@@ -19,9 +19,9 @@
   "changelog": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-quest-log/releases/latest/",
   "version": "0.7.12",
   "compatibility": {
-    "minimum": "11",
-    "verified": "11",
-    "maximum": "11"
+    "minimum": "12",
+    "verified": "12",
+    "maximum": "12"
   },
   "esmodules": [
     "./src/init.js"

--- a/src/control/QuestDB.js
+++ b/src/control/QuestDB.js
@@ -320,8 +320,8 @@ export default class QuestDB
       const defaultPerm = game.settings.get(constants.moduleName, settings.defaultPermission);
 
       const permission = {
-         default: typeof CONST.DOCUMENT_PERMISSION_LEVELS[defaultPerm] === 'number' ?
-          CONST.DOCUMENT_PERMISSION_LEVELS[defaultPerm] : CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER
+         default: typeof CONST.DOCUMENT_OWNERSHIP_LEVELS[defaultPerm] === 'number' ?
+          CONST.DOCUMENT_OWNERSHIP_LEVELS[defaultPerm] : CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER
       };
 
       // Used for a player created quest setting and the quest as 'available' for normal players or 'hidden' for
@@ -329,7 +329,7 @@ export default class QuestDB
       if (!game.user.isGM)
       {
          data.status = Utils.isTrustedPlayerEdit() ? questStatus.inactive : questStatus.available;
-         permission[game.user.id] = CONST.DOCUMENT_PERMISSION_LEVELS.OWNER;
+         permission[game.user.id] = CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER;
       }
 
       const parentQuest = QuestDB.getQuest(parentId);
@@ -971,7 +971,7 @@ const s_GET_QUEST_ENTRY = (questId) =>
  * GM level users always can observe any quests. Trusted players w/ the module setting
  * {@link FQLSettings.trustedPlayerEdit} enabled and the owner of the quest can observe quests in the inactive status.
  * Otherwise quests are only observable by players when the default or personal permission is
- * {@link CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER} or higher.
+ * {@link CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER} or higher.
  *
  * @param {QuestData}      content - The serialized Quest data stored in the journal entry.
  *
@@ -1001,7 +1001,7 @@ const s_IS_OBSERVABLE = (content, entry, isTrustedPlayerEdit = Utils.isTrustedPl
       else
       {
          // Otherwise no one can see hidden / inactive quests; perform user permission check for observer.
-         isObservable = !isInactive && entry.testUserPermission(game.user, CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER);
+         isObservable = !isInactive && entry.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER);
       }
    }
 

--- a/src/control/Utils.js
+++ b/src/control/Utils.js
@@ -197,7 +197,7 @@ export default class Utils
 
          const checkPerm = typeof permissionCheck === 'boolean' ? permissionCheck : true;
 
-         if (checkPerm && !doc.testUserPermission(game.user, CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER))
+         if (checkPerm && !doc.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER))
          {
             ui.notifications.warn('ForienQuestLog.API.Utils.Notifications.NoPermission', { localize: true });
             return null;
@@ -386,7 +386,7 @@ export default class Utils
             return null;
          }
 
-         if (permissionCheck && !document.testUserPermission(game.user, CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER))
+         if (permissionCheck && !document.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER))
          {
             ui.notifications.warn('ForienQuestLog.API.Utils.Notifications.NoPermission', { localize: true });
             return null;

--- a/src/model/Quest.js
+++ b/src/model/Quest.js
@@ -90,7 +90,7 @@ export default class Quest
 
       if (this.entry && typeof FVTTCompat.ownership(this.entry) === 'object')
       {
-         if (FVTTCompat.ownership(this.entry).default >= CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER) { return false; }
+         if (FVTTCompat.ownership(this.entry).default >= CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER) { return false; }
 
          for (const [userId, permission] of Object.entries(FVTTCompat.ownership(this.entry)))
          {
@@ -100,7 +100,7 @@ export default class Quest
 
             if (!user || user.isGM) { continue; }
 
-            if (permission >= CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER)
+            if (permission >= CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER)
             {
                isHidden = false;
                break;
@@ -135,7 +135,7 @@ export default class Quest
       if (Utils.isTrustedPlayerEdit() && isInactive) { return this.isOwner; }
 
       // Otherwise no one can see hidden / inactive quests; perform user permission check for observer.
-      return !isInactive && this.entry.testUserPermission(game.user, CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER);
+      return !isInactive && this.entry.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER);
    }
 
    /**
@@ -146,7 +146,7 @@ export default class Quest
    get isOwner()
    {
       return game.user.isGM ||
-       (this.entry && this.entry.testUserPermission(game.user, CONST.DOCUMENT_PERMISSION_LEVELS.OWNER));
+       (this.entry && this.entry.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER));
    }
 
    /**
@@ -160,7 +160,7 @@ export default class Quest
       let isPersonal = false;
 
       if (this.entry && typeof FVTTCompat.ownership(this.entry) === 'object' &&
-       FVTTCompat.ownership(this.entry).default < CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER)
+       FVTTCompat.ownership(this.entry).default < CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER)
       {
          for (const [userId, permission] of Object.entries(FVTTCompat.ownership(this.entry)))
          {
@@ -170,7 +170,7 @@ export default class Quest
 
             if (!user || user.isGM) { continue; }
 
-            if (permission < CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER) { continue; }
+            if (permission < CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER) { continue; }
 
             isPersonal = true;
             break;
@@ -294,7 +294,7 @@ export default class Quest
 
             if (!user || user.isGM) { continue; }
 
-            if (permission < CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER) { continue; }
+            if (permission < CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER) { continue; }
 
             users.push(user);
          }


### PR DESCRIPTION
- Naïve find/replace `DOCUMENT_PERMISSION_LEVELS` to `DOCUMENT_OWNERSHIP_LEVELS`
- Bump Target/Min versions in module.json